### PR TITLE
faster_rendering

### DIFF
--- a/waymax/visualization/utils.py
+++ b/waymax/visualization/utils.py
@@ -169,7 +169,7 @@ def plot_numpy_bounding_boxes(
     cr = pt + width / 2 * ut
     cf = pt + length / 2 * u
 
-    # Draw bboxes.
+    # Draw bboxes and heading arrow.
     ax.plot(
         [tl[0, :], tr[0, :], br[0, :], bl[0, :], tl[0, :], cl[0, :], cr[0, :], cf[0, :], cl[0, :]],
         [tl[1, :], tr[1, :], br[1, :], bl[1, :], tl[1, :], cl[1, :], cr[1, :], cf[1, :], cl[1, :]],
@@ -178,16 +178,6 @@ def plot_numpy_bounding_boxes(
         alpha=alpha,
         label=label,
     )
-
-    # # Draw heading arrow.
-    # ax.plot(
-    #     [cl[0, :], cr[0, :], cf[0, :], cl[0, :]],
-    #     [cl[1, :], cr[1, :], cf[1, :], cl[1, :]],
-    #     color=color,
-    #     zorder=4,
-    #     alpha=alpha,
-    #     label=label,
-    # )
 
 def plot_numpy_rays(
     ax: plt.Axes,

--- a/waymax/visualization/utils.py
+++ b/waymax/visualization/utils.py
@@ -171,23 +171,23 @@ def plot_numpy_bounding_boxes(
 
     # Draw bboxes.
     ax.plot(
-        [tl[0, :], tr[0, :], br[0, :], bl[0, :], tl[0, :]],
-        [tl[1, :], tr[1, :], br[1, :], bl[1, :], tl[1, :]],
+        [tl[0, :], tr[0, :], br[0, :], bl[0, :], tl[0, :], cl[0, :], cr[0, :], cf[0, :], cl[0, :]],
+        [tl[1, :], tr[1, :], br[1, :], bl[1, :], tl[1, :], cl[1, :], cr[1, :], cf[1, :], cl[1, :]],
         color=color,
         zorder=4,
         alpha=alpha,
         label=label,
     )
 
-    # Draw heading arrow.
-    ax.plot(
-        [cl[0, :], cr[0, :], cf[0, :], cl[0, :]],
-        [cl[1, :], cr[1, :], cf[1, :], cl[1, :]],
-        color=color,
-        zorder=4,
-        alpha=alpha,
-        label=label,
-    )
+    # # Draw heading arrow.
+    # ax.plot(
+    #     [cl[0, :], cr[0, :], cf[0, :], cl[0, :]],
+    #     [cl[1, :], cr[1, :], cf[1, :], cl[1, :]],
+    #     color=color,
+    #     zorder=4,
+    #     alpha=alpha,
+    #     label=label,
+    # )
 
 def plot_numpy_rays(
     ax: plt.Axes,


### PR DESCRIPTION
Call `ax.plot()` once instead of twice in `plot_numpy_bounding_boxes`, I got a 40% faster `visualization.plot_simulator_state` (tested before the introduction of `plot_numpy_rays`)